### PR TITLE
Stop the server before trying to make the next request

### DIFF
--- a/lib/server_stuff.rb
+++ b/lib/server_stuff.rb
@@ -4,19 +4,19 @@ require 'socket'
 
 class Server
   attr_accessor :code, :body
-  
+
   def initialize(port)
     @port = port
     @code = code
     @body = body
     yield self if block_given?
   end
-  
+
   def start
-    server = TCPServer.new(@port)
+    @server = TCPServer.new(@port)
     puts "Running now"
     loop do
-      s = server.accept
+      s = @server.accept
       request = s.gets
       STDERR.puts request
       response = "HTTP/1.1 #{@code} OK\r\n" +
@@ -29,4 +29,8 @@ class Server
     end
   end
 
+  def stop
+    @server.close_read
+    @server.close_write
+  end
 end

--- a/spec/acceptance_spec.rb
+++ b/spec/acceptance_spec.rb
@@ -18,22 +18,25 @@ RSpec.describe 'server' do
     t = Thread.new {server.start}
     t.abort_on_exception = true
     client_response = Net::HTTP.get_response('localhost','/',8889)
+    t.exit
+    server.stop
     expect(client_response["Content-Length"]).to eq '11'
     expect(client_response.code).to eq '200'
     expect(client_response.body).to eq "Hello World"
-    t.exit
   end
 
   it "responds to web requests" do
     server = Server.new(8889) do |server_response|
       server_response.code = 301
+      server_response.body = "html"
     end
     t = Thread.new {server.start}
     t.abort_on_exception = true
     client_response = Net::HTTP.get_response('localhost','/',8889)
+    t.exit
+    server.stop
     #expect(client_response["Location"]).to eq 'http://www.google.com/'
     expect(client_response.code).to eq '301'
     expect(client_response.body).to match /html/i
-    t.exit
   end
 end


### PR DESCRIPTION
Took a bit, but I got it:

Since it's in a loop, and hits the `accept` method, you have to kill the thread first. Then, you can tell it to `stop_read` and `stop_write`, which frees the port for the next connection.
